### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,13 @@
 # against bad commits.
 
 name: build
-on: [pull_request, push]
+on:
+  pull_request:
+    branches:
+      - 'main'
+  push:
+    tags-ignore:
+      - '**'
 
 jobs:
   validate:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     tags: v[0-9]+.[0-9]+.[0-9]+-[1-9]+.[0-9]+.[0-9]+
 
-
 jobs:
   build:
     strategy:
@@ -30,7 +29,7 @@ jobs:
           arguments: build
 
       - name: Upload assets to GitHub, Modrinth and CurseForge
-        uses: Kir-Antipov/mc-publish@v3
+        uses: Kir-Antipov/mc-publish@v3.1
         with:
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
           #curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}


### PR DESCRIPTION
restrict build workflow on `pull_request`  to branch `main` & ignore `push` on tag and fix `mc-publish` version. changed to `v3.1`